### PR TITLE
Update AndroidManifest.xml Fix Lint Forgeound Android X issue

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/bgd_file_paths" />
         </provider>
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
 
     </application>
 </manifest>


### PR DESCRIPTION
The Android Lint check is failing because the package is missing a required foreground service type specification in the AndroidManifest.xml file.